### PR TITLE
Static breadcrumb ignored

### DIFF
--- a/blocks/breadcrumb/breadcrumb.js
+++ b/blocks/breadcrumb/breadcrumb.js
@@ -14,7 +14,7 @@ function extractTitleFromHtml(rawHtml, pagePath) {
   const doc = parser.parseFromString(rawHtml, "text/html");
 
   // 0. Get text from breadcrumb component
-  const breadcrumbBlockTitle = doc.querySelector('.breadcrumb');
+  const breadcrumbBlockTitle = doc.querySelector('.breadcrumb:not(.static-breadcrumb)');
   if (breadcrumbBlockTitle && breadcrumbBlockTitle.textContent?.trim()) {
     return breadcrumbBlockTitle.textContent?.trim();
   }


### PR DESCRIPTION
Test URLs:
- Before: https://main--tmb-aem-eds-en--kevalteknopoint.aem.live/tmbank/au/en/home-loans/first-home-buyer
- After: https://icons-removal--tmb-aem-eds-en--kevalteknopoint.aem.live/tmbank/au/en/home-loans/first-home-buyer
